### PR TITLE
Move gitignore to root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Default ignored files
 /shelf/
 /workspace.xml
-*.iml
+**.iml


### PR DESCRIPTION
Move gitignore out of idea folder to root, to apply it to git directly instead of intellij git integration.